### PR TITLE
chore: remove R3 logo from book, not really relevant for this course

### DIFF
--- a/_extensions/rostools/r3-theme/_extension.yml
+++ b/_extensions/rostools/r3-theme/_extension.yml
@@ -23,7 +23,6 @@ contributes:
         - custom-slides.scss
       menu: true
       progress: true
-      logo: favicon.ico
 
   project:
     project:
@@ -32,7 +31,6 @@ contributes:
       execute-dir: project
 
     book:
-      favicon: "favicon.ico"
       repo-branch: main
       repo-actions: [edit, issue, source]
       search: true


### PR DESCRIPTION
This just removes it from the browser tab and other locations.